### PR TITLE
Simplify asyncio main loop setup

### DIFF
--- a/examples/basic_audio_streaming.py
+++ b/examples/basic_audio_streaming.py
@@ -32,8 +32,4 @@ async def amain() -> None:
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop_policy().get_event_loop()
-    try:
-        loop.run_until_complete(amain())
-    finally:
-        loop.close()
+    asyncio.run(amain())

--- a/examples/basic_generation.py
+++ b/examples/basic_generation.py
@@ -20,8 +20,4 @@ async def amain() -> None:
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop_policy().get_event_loop()
-    try:
-        loop.run_until_complete(amain())
-    finally:
-        loop.close()
+    asyncio.run(amain())

--- a/examples/dynamic_voice_selection.py
+++ b/examples/dynamic_voice_selection.py
@@ -26,8 +26,4 @@ async def amain() -> None:
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop_policy().get_event_loop()
-    try:
-        loop.run_until_complete(amain())
-    finally:
-        loop.close()
+    asyncio.run(amain())

--- a/examples/streaming_with_subtitles.py
+++ b/examples/streaming_with_subtitles.py
@@ -33,8 +33,4 @@ async def amain() -> None:
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop_policy().get_event_loop()
-    try:
-        loop.run_until_complete(amain())
-    finally:
-        loop.close()
+    asyncio.run(amain())

--- a/src/edge_tts/util.py
+++ b/src/edge_tts/util.py
@@ -133,11 +133,7 @@ async def amain() -> None:
 
 def main() -> None:
     """Run the main function using asyncio."""
-    loop = asyncio.get_event_loop_policy().get_event_loop()
-    try:
-        loop.run_until_complete(amain())
-    finally:
-        loop.close()
+    asyncio.run(amain())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR updates the asyncio main loop handling to ensure compatibility with Python 3.7 and newer versions, switching from the outdated loop setup to the more efficient asyncio.run() function.

In Python 3.12, running the example .py files triggers a DeprecationWarning indicating that there is no current event loop.

> basic_generation.py:23: DeprecationWarning: There is no current event loop
>   loop = asyncio.get_event_loop_policy().get_event_loop()
