### PR TITLE
Add sync versions of stream and save methods

### DIFF
--- a/examples/basic_sync_audio_streaming.py
+++ b/examples/basic_sync_audio_streaming.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+"""
+Basic audio streaming example for sync interface
+
+"""
+
+import edge_tts
+
+TEXT = "Hello World!"
+VOICE = "en-GB-SoniaNeural"
+OUTPUT_FILE = "test.mp3"
+
+
+def main() -> None:
+    """Main function to process audio and metadata synchronously."""
+    communicate = edge_tts.Communicate(TEXT, VOICE)
+    with open(OUTPUT_FILE, "wb") as file:
+        for chunk in communicate.stream_sync():
+            if chunk["type"] == "audio":
+                file.write(chunk["data"])
+            elif chunk["type"] == "WordBoundary":
+                print(f"WordBoundary: {chunk}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/basic_sync_generation.py
+++ b/examples/basic_sync_generation.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+"""
+Basic example of edge_tts usage in synchronous function
+"""
+
+import edge_tts
+
+TEXT = "Hello World!"
+VOICE = "en-GB-SoniaNeural"
+OUTPUT_FILE = "test.mp3"
+
+
+def main() -> None:
+    """Main function"""
+    communicate = edge_tts.Communicate(TEXT, VOICE)
+    communicate.save_sync(OUTPUT_FILE)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sync_audio_generation_in_async_context.py
+++ b/examples/sync_audio_generation_in_async_context.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+"""
+This example shows that sync version of save function also works when run from 
+a sync function called itself from an async function.
+The simple implementation of save_sync() with only asyncio.run would fail in this scenario, 
+that's why ThreadPoolExecutor is used in implementation.
+
+"""
+
+import asyncio
+
+import edge_tts
+
+TEXT = "Hello World!"
+VOICE = "en-GB-SoniaNeural"
+OUTPUT_FILE = "test.mp3"
+
+
+def sync_main() -> None:
+    """Main function"""
+    communicate = edge_tts.Communicate(TEXT, VOICE)
+    communicate.save_sync(OUTPUT_FILE)
+
+
+async def amain() -> None:
+    """Main function"""
+    sync_main()
+
+
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop_policy().get_event_loop()
+    try:
+        loop.run_until_complete(amain())
+    finally:
+        loop.close()

--- a/examples/sync_audio_stream_in_async_context.py
+++ b/examples/sync_audio_stream_in_async_context.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+"""
+This example shows that sync version of string function also works when run from
+a sync function called itself from an async function.
+The simple implementation of stream_sync() with only asyncio.run would fail in this scenario,
+that's why ThreadPoolExecutor is used in implementation.
+
+"""
+
+import asyncio
+
+import edge_tts
+
+TEXT = "Hello World!"
+VOICE = "en-GB-SoniaNeural"
+OUTPUT_FILE = "test.mp3"
+
+
+def main() -> None:
+    """Main function to process audio and metadata synchronously."""
+    communicate = edge_tts.Communicate(TEXT, VOICE)
+    with open(OUTPUT_FILE, "wb") as file:
+        for chunk in communicate.stream_sync():
+            if chunk["type"] == "audio":
+                file.write(chunk["data"])
+            elif chunk["type"] == "WordBoundary":
+                print(f"WordBoundary: {chunk}")
+
+
+async def amain():
+    main()
+
+
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop_policy().get_event_loop()
+    try:
+        loop.run_until_complete(amain())
+    finally:
+        loop.close()

--- a/examples/sync_audio_stream_in_async_context.py
+++ b/examples/sync_audio_stream_in_async_context.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
 
 """
-This example shows that sync version of string function also works when run from
-a sync function called itself from an async function.
-The simple implementation of stream_sync() with only asyncio.run would fail in this scenario,
-that's why ThreadPoolExecutor is used in implementation.
-
+This example shows the sync version of stream function which also
+works when run from a sync function called itself from an async function.
 """
 
 import asyncio
@@ -28,7 +25,12 @@ def main() -> None:
                 print(f"WordBoundary: {chunk}")
 
 
-async def amain():
+async def amain() -> None:
+    """ "
+    Async main function to call sync main function
+
+    This demonstrates that this works even when called from an async function.
+    """
     main()
 
 


### PR DESCRIPTION
This pull request should solve the issue: https://github.com/rany2/edge-tts/issues/194
The implementation is a bit more complicated than the simplest asyncio.run() of the save and stream methods.
That's because I've wanted to use this synchronous interface in my Fastapi app, and simple asyncio.run() would give me errors that the event loop is alread running. That's because Fastapi is itself async, and I would run synchronous function inside async fastapi handler, and then from this synchronous function I wanted to call edge-tts generation. I've reproduced similar scenario in two example files: examples/sync_audio_generation_in_async_context.py and examples/sync_audio_stream_in_async_context.py.
I've roughly checked the performance of my solution and from what I've saw there should be no visible performance hit when using ThreadPoolExecutor instead of just asyncio.run().
