### PR TITLE
Bump edge_tts version to 6.1.15

### DIFF
--- a/src/edge_tts/version.py
+++ b/src/edge_tts/version.py
@@ -1,4 +1,4 @@
 """Edge TTS version information."""
 
-__version__ = "6.1.14"
+__version__ = "6.1.15"
 __version_info__ = tuple(int(num) for num in __version__.split("."))


### PR DESCRIPTION
Pending confirmation that the fix for https://github.com/rany2/edge-tts/issues/286 in master works.