### PR TITLE
Accept - as a valid input parameter

### DIFF
--- a/src/edge_tts/util.py
+++ b/src/edge_tts/util.py
@@ -117,9 +117,7 @@ async def amain() -> None:
         sys.exit(0)
 
     if args.file is not None:
-        # we need to use sys.stdin.read() because some devices
-        # like Windows and Termux don't have a /dev/stdin.
-        if args.file == "/dev/stdin":
+        if args.file in ("-", "/dev/stdin"):
             args.text = sys.stdin.read()
         else:
             with open(args.file, "r", encoding="utf-8") as file:


### PR DESCRIPTION
We won't do the same for the output parameter as it is the default behavior when --write-media is not set.

Closes: https://github.com/rany2/edge-tts/issues/216