### PR TITLE
Add support for custom aiohttp connector

### DIFF
--- a/src/edge_tts/submaker.py
+++ b/src/edge_tts/submaker.py
@@ -15,7 +15,7 @@ class SubMaker:
 
     def add_cue(self, timestamp: Tuple[float, float], text: str) -> None:
         """
-        Add a subtitle part to the SubMaker object.
+        Add a cue to the SubMaker object.
 
         Args:
             timestamp (tuple): The offset and duration of the subtitle.

--- a/src/edge_tts/voices.py
+++ b/src/edge_tts/voices.py
@@ -55,7 +55,9 @@ async def __list_voices(
     return data
 
 
-async def list_voices(*, proxy: Optional[str] = None) -> List[Voice]:
+async def list_voices(
+    *, connector: Optional[aiohttp.BaseConnector] = None, proxy: Optional[str] = None
+) -> List[Voice]:
     """
     List all available voices and their attributes.
 
@@ -63,13 +65,14 @@ async def list_voices(*, proxy: Optional[str] = None) -> List[Voice]:
     all available voices.
 
     Args:
+        connector (Optional[aiohttp.BaseConnector]): The connector to use for the request.
         proxy (Optional[str]): The proxy to use for the request.
 
     Returns:
         List[Voice]: A list of voices and their attributes.
     """
     ssl_ctx = ssl.create_default_context(cafile=certifi.where())
-    async with aiohttp.ClientSession(trust_env=True) as session:
+    async with aiohttp.ClientSession(connector=connector, trust_env=True) as session:
         try:
             data = await __list_voices(session, ssl_ctx, proxy)
         except aiohttp.ClientResponseError as e:


### PR DESCRIPTION
This should allow users that need it to add support for SOCKS5 in their application via https://pypi.org/project/aiohttp-socks/.

Partially fixes: https://github.com/rany2/edge-tts/issues/147