### PR TITLE
Use the short name for the default voice

### DIFF
--- a/src/edge_tts/communicate.py
+++ b/src/edge_tts/communicate.py
@@ -244,7 +244,7 @@ class Communicate:
     def __init__(
         self,
         text: str,
-        voice: str = "Microsoft Server Speech Text to Speech Voice (en-US, AriaNeural)",
+        voice: str = "en-US-AriaNeural",
         *,
         rate: str = "+0%",
         volume: str = "+0%",


### PR DESCRIPTION
Switch to en-US-AriaNeural for the default voice name. It will be converted automatically to the complete voice name anyway.