### PR TITLE
Fix typo in SubMaker's feed() logic

### DIFF
--- a/src/edge_tts/submaker.py
+++ b/src/edge_tts/submaker.py
@@ -31,8 +31,8 @@ class SubMaker:
         self.cues.append(
             srt.Subtitle(
                 index=len(self.cues) + 1,
-                start=srt.timedelta(microseconds=msg["duration"] / 10),
-                end=srt.timedelta(microseconds=(msg["duration"] + msg["offset"]) / 10),
+                start=srt.timedelta(microseconds=msg["offset"] / 10),
+                end=srt.timedelta(microseconds=(msg["offset"] + msg["duration"]) / 10),
                 content=msg["text"],
             )
         )


### PR DESCRIPTION
The start time should be the offset and the end time is offset + duration.