### PR TITLE
Support native playback on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you wish to play it back immediately with subtitles, you could use the `edge-
 
     $ edge-playback --text "Hello, world!"
 
-Note that `edge-playback` requires the installation of the [`mpv` command line player](https://mpv.io/).
+Note that `edge-playback` requires the installation of the [`mpv` command line player](https://mpv.io/), except on Windows.
 
 All `edge-tts` commands work with `edge-playback` with the exception of the `--write-media`, `--write-subtitles` and `--list-voices` options.
 

--- a/src/edge_playback/__init__.py
+++ b/src/edge_playback/__init__.py
@@ -1,5 +1,6 @@
 """The edge_playback package wraps the functionality of mpv and edge-tts to generate
-text-to-speech (TTS) using edge-tts and then plays back the generated audio using mpv."""
+text-to-speech (TTS) using edge-tts and then plays back the generated audio using mpv.
+"""
 
 from .__main__ import _main
 

--- a/src/edge_playback/__main__.py
+++ b/src/edge_playback/__main__.py
@@ -56,7 +56,8 @@ def _main() -> None:
             srt_fname = subtitle.name
 
         print(f"Media file: {mp3_fname}")
-        print(f"Subtitle file: {srt_fname}\n")
+        if srt_fname:
+            print(f"Subtitle file: {srt_fname}\n")
 
         edge_tts_cmd = ["edge-tts", f"--write-media={mp3_fname}"]
         if srt_fname:

--- a/src/edge_playback/__main__.py
+++ b/src/edge_playback/__main__.py
@@ -3,7 +3,6 @@
 import argparse
 import ctypes
 import os
-import platform
 import subprocess
 import sys
 import tempfile
@@ -30,7 +29,7 @@ def _main() -> None:
     )
     args, tts_args = parser.parse_known_args()
 
-    use_mpv = platform.system() != "Windows" or args.mpv
+    use_mpv = sys.platform != "win32" or args.mpv
 
     deps = ["edge-tts"]
     if use_mpv:
@@ -72,7 +71,7 @@ def _main() -> None:
         ) as process:
             process.communicate()
 
-        if platform.system() == "Windows" and not use_mpv:
+        if sys.platform == "win32" and not use_mpv:
 
             def mci_send(msg: str) -> None:
                 result = ctypes.windll.winmm.mciSendStringW(msg, 0, 0, 0)

--- a/src/edge_playback/util.py
+++ b/src/edge_playback/util.py
@@ -1,0 +1,8 @@
+"""Utility functions for the command line interface."""
+
+import sys
+
+
+def pr_err(msg: str) -> None:
+    """Print to stderr."""
+    print(msg, file=sys.stderr)

--- a/src/edge_playback/util.py
+++ b/src/edge_playback/util.py
@@ -1,4 +1,4 @@
-"""Utility functions for the command line interface."""
+"""Utility functions for edge-playback"""
 
 import sys
 

--- a/src/edge_playback/win32_playback.py
+++ b/src/edge_playback/win32_playback.py
@@ -7,10 +7,11 @@ from .util import pr_err
 
 def play_mp3_win32(mp3_fname: str) -> None:
     """Play mp3 file with given path using win32 API"""
-    # pylint: disable-next=import-outside-toplevel
-    from ctypes import create_unicode_buffer, windll, wintypes
 
     if sys.platform == "win32":
+        # pylint: disable-next=import-outside-toplevel
+        from ctypes import create_unicode_buffer, windll, wintypes
+
         _GetShortPathNameW = windll.kernel32.GetShortPathNameW
         _GetShortPathNameW.argtypes = [
             wintypes.LPCWSTR,

--- a/src/edge_playback/win32_playback.py
+++ b/src/edge_playback/win32_playback.py
@@ -1,0 +1,43 @@
+"""Functions to play audio on Windows using native win32 APIs"""
+
+from ctypes import create_unicode_buffer, windll, wintypes
+
+from .util import pr_err
+
+_GetShortPathNameW = windll.kernel32.GetShortPathNameW
+_GetShortPathNameW.argtypes = [wintypes.LPCWSTR, wintypes.LPWSTR, wintypes.DWORD]
+_GetShortPathNameW.restype = wintypes.DWORD
+
+
+def get_short_path_name(long_name: str) -> str:
+    """
+    Gets the DOS-safe short path name of a given long path.
+    http://stackoverflow.com/a/23598461/200291
+    """
+    output_buf_size = 0
+    while True:
+        output_buf = create_unicode_buffer(output_buf_size)
+        needed = _GetShortPathNameW(long_name, output_buf, output_buf_size)
+        if output_buf_size >= needed:
+            return output_buf.value
+        output_buf_size = needed
+
+
+mciSendStringW = windll.winmm.mciSendStringW
+
+
+def mci_send(msg: str) -> None:
+    """Send MCI command string"""
+    result = mciSendStringW(msg, 0, 0, 0)
+    if result != 0:
+        pr_err(f"Error {result} in mciSendString {msg}")
+
+
+def play_mp3_win32(mp3_fname: str) -> None:
+    """Play mp3 file with given path using win32 API"""
+    mp3_shortname = get_short_path_name(mp3_fname)
+
+    mci_send("Close All")
+    mci_send(f'Open "{mp3_shortname}" Type MPEGVideo Alias theMP3')
+    mci_send("Play theMP3 Wait")
+    mci_send("Close theMP3")

--- a/src/edge_playback/win32_playback.py
+++ b/src/edge_playback/win32_playback.py
@@ -7,6 +7,7 @@ from .util import pr_err
 
 def play_mp3_win32(mp3_fname: str) -> None:
     """Play mp3 file with given path using win32 API"""
+    # pylint: disable-next=import-outside-toplevel
     from ctypes import create_unicode_buffer, windll, wintypes
 
     if sys.platform == "win32":

--- a/src/edge_playback/win32_playback.py
+++ b/src/edge_playback/win32_playback.py
@@ -12,13 +12,13 @@ def play_mp3_win32(mp3_fname: str) -> None:
         # pylint: disable-next=import-outside-toplevel
         from ctypes import create_unicode_buffer, windll, wintypes
 
-        _GetShortPathNameW = windll.kernel32.GetShortPathNameW
-        _GetShortPathNameW.argtypes = [
+        _get_short_path_name_w = windll.kernel32.GetShortPathNameW
+        _get_short_path_name_w.argtypes = [
             wintypes.LPCWSTR,
             wintypes.LPWSTR,
             wintypes.DWORD,
         ]
-        _GetShortPathNameW.restype = wintypes.DWORD
+        _get_short_path_name_w.restype = wintypes.DWORD
 
         def get_short_path_name(long_name: str) -> str:
             """
@@ -28,16 +28,16 @@ def play_mp3_win32(mp3_fname: str) -> None:
             output_buf_size = 0
             while True:
                 output_buf = create_unicode_buffer(output_buf_size)
-                needed = _GetShortPathNameW(long_name, output_buf, output_buf_size)
+                needed = _get_short_path_name_w(long_name, output_buf, output_buf_size)
                 if output_buf_size >= needed:
                     return output_buf.value
                 output_buf_size = needed
 
-        mciSendStringW = windll.winmm.mciSendStringW
+        mci_send_string_w = windll.winmm.mciSendStringW
 
         def mci_send(msg: str) -> None:
             """Send MCI command string"""
-            result = mciSendStringW(msg, 0, 0, 0)
+            result = mci_send_string_w(msg, 0, 0, 0)
             if result != 0:
                 pr_err(f"Error {result} in mciSendString {msg}")
 

--- a/src/edge_playback/win32_playback.py
+++ b/src/edge_playback/win32_playback.py
@@ -1,43 +1,49 @@
 """Functions to play audio on Windows using native win32 APIs"""
 
-from ctypes import create_unicode_buffer, windll, wintypes
+import sys
 
 from .util import pr_err
-
-_GetShortPathNameW = windll.kernel32.GetShortPathNameW
-_GetShortPathNameW.argtypes = [wintypes.LPCWSTR, wintypes.LPWSTR, wintypes.DWORD]
-_GetShortPathNameW.restype = wintypes.DWORD
-
-
-def get_short_path_name(long_name: str) -> str:
-    """
-    Gets the DOS-safe short path name of a given long path.
-    http://stackoverflow.com/a/23598461/200291
-    """
-    output_buf_size = 0
-    while True:
-        output_buf = create_unicode_buffer(output_buf_size)
-        needed = _GetShortPathNameW(long_name, output_buf, output_buf_size)
-        if output_buf_size >= needed:
-            return output_buf.value
-        output_buf_size = needed
-
-
-mciSendStringW = windll.winmm.mciSendStringW
-
-
-def mci_send(msg: str) -> None:
-    """Send MCI command string"""
-    result = mciSendStringW(msg, 0, 0, 0)
-    if result != 0:
-        pr_err(f"Error {result} in mciSendString {msg}")
 
 
 def play_mp3_win32(mp3_fname: str) -> None:
     """Play mp3 file with given path using win32 API"""
-    mp3_shortname = get_short_path_name(mp3_fname)
+    from ctypes import create_unicode_buffer, windll, wintypes
 
-    mci_send("Close All")
-    mci_send(f'Open "{mp3_shortname}" Type MPEGVideo Alias theMP3')
-    mci_send("Play theMP3 Wait")
-    mci_send("Close theMP3")
+    if sys.platform == "win32":
+        _GetShortPathNameW = windll.kernel32.GetShortPathNameW
+        _GetShortPathNameW.argtypes = [
+            wintypes.LPCWSTR,
+            wintypes.LPWSTR,
+            wintypes.DWORD,
+        ]
+        _GetShortPathNameW.restype = wintypes.DWORD
+
+        def get_short_path_name(long_name: str) -> str:
+            """
+            Gets the DOS-safe short path name of a given long path.
+            http://stackoverflow.com/a/23598461/200291
+            """
+            output_buf_size = 0
+            while True:
+                output_buf = create_unicode_buffer(output_buf_size)
+                needed = _GetShortPathNameW(long_name, output_buf, output_buf_size)
+                if output_buf_size >= needed:
+                    return output_buf.value
+                output_buf_size = needed
+
+        mciSendStringW = windll.winmm.mciSendStringW
+
+        def mci_send(msg: str) -> None:
+            """Send MCI command string"""
+            result = mciSendStringW(msg, 0, 0, 0)
+            if result != 0:
+                pr_err(f"Error {result} in mciSendString {msg}")
+
+        mp3_shortname = get_short_path_name(mp3_fname)
+
+        mci_send("Close All")
+        mci_send(f'Open "{mp3_shortname}" Type MPEGVideo Alias theMP3')
+        mci_send("Play theMP3 Wait")
+        mci_send("Close theMP3")
+    else:
+        raise NotImplementedError("Function only available on Windows")

--- a/src/edge_playback/win32_playback.py
+++ b/src/edge_playback/win32_playback.py
@@ -8,44 +8,45 @@ from .util import pr_err
 def play_mp3_win32(mp3_fname: str) -> None:
     """Play mp3 file with given path using win32 API"""
 
-    if sys.platform == "win32":
-        # pylint: disable-next=import-outside-toplevel
-        from ctypes import create_unicode_buffer, windll, wintypes
-
-        _get_short_path_name_w = windll.kernel32.GetShortPathNameW
-        _get_short_path_name_w.argtypes = [
-            wintypes.LPCWSTR,
-            wintypes.LPWSTR,
-            wintypes.DWORD,
-        ]
-        _get_short_path_name_w.restype = wintypes.DWORD
-
-        def get_short_path_name(long_name: str) -> str:
-            """
-            Gets the DOS-safe short path name of a given long path.
-            http://stackoverflow.com/a/23598461/200291
-            """
-            output_buf_size = 0
-            while True:
-                output_buf = create_unicode_buffer(output_buf_size)
-                needed = _get_short_path_name_w(long_name, output_buf, output_buf_size)
-                if output_buf_size >= needed:
-                    return output_buf.value
-                output_buf_size = needed
-
-        mci_send_string_w = windll.winmm.mciSendStringW
-
-        def mci_send(msg: str) -> None:
-            """Send MCI command string"""
-            result = mci_send_string_w(msg, 0, 0, 0)
-            if result != 0:
-                pr_err(f"Error {result} in mciSendString {msg}")
-
-        mp3_shortname = get_short_path_name(mp3_fname)
-
-        mci_send("Close All")
-        mci_send(f'Open "{mp3_shortname}" Type MPEGVideo Alias theMP3')
-        mci_send("Play theMP3 Wait")
-        mci_send("Close theMP3")
-    else:
+    if sys.platform != "win32":
         raise NotImplementedError("Function only available on Windows")
+
+    # pylint: disable-next=import-outside-toplevel
+    from ctypes import create_unicode_buffer, windll, wintypes  # type: ignore
+
+    _get_short_path_name_w = windll.kernel32.GetShortPathNameW
+    _get_short_path_name_w.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.LPWSTR,
+        wintypes.DWORD,
+    ]
+    _get_short_path_name_w.restype = wintypes.DWORD
+
+    def get_short_path_name(long_name: str) -> str:
+        """
+        Gets the DOS-safe short path name of a given long path.
+        http://stackoverflow.com/a/23598461/200291
+        """
+        output_buf_size = 0
+        while True:
+            output_buf = create_unicode_buffer(output_buf_size)
+            needed = _get_short_path_name_w(long_name, output_buf, output_buf_size)
+            if output_buf_size >= needed:
+                return output_buf.value
+            output_buf_size = needed
+
+    mci_send_string_w = windll.winmm.mciSendStringW
+
+    def mci_send(msg: str) -> None:
+        """Send MCI command string"""
+        result = mci_send_string_w(msg, 0, 0, 0)
+        if result != 0:
+            pr_err(f"Error {result} in mciSendString {msg}. Exiting.")
+            sys.exit(1)
+
+    mp3_shortname = get_short_path_name(mp3_fname)
+
+    mci_send("Close All")
+    mci_send(f'Open "{mp3_shortname}" Type MPEGVideo Alias theMP3')
+    mci_send("Play theMP3 Wait")
+    mci_send("Close theMP3")


### PR DESCRIPTION
This PR adds support for playing generated mp3 files on Windows with no external dependencies, just built-in Python standard library functions and native Windows APIs, so users on Windows no longer need to have mpv installed.

One drawback of this method is that isn't possible to stop playback with ctrl-C while the audio is playing. In theory, it should be possible to fix this with an additional dependency (pywin32), although I haven't tried that out yet, and since it's a windows-only library it'd take some fiddling in setuptools, so I opted for the simpler version here. (An _even simpler_ version would be passing the file name to `winsound.PlaySound`, but unfortunately that only takes .wav files)