### PR TITLE
fix: Split only on valid utf-8 boundary

### DIFF
--- a/src/edge_tts/communicate.py
+++ b/src/edge_tts/communicate.py
@@ -123,11 +123,24 @@ def split_text_by_byte_length(
         raise ValueError("byte_length must be greater than 0")
 
     while len(text) > byte_length:
-        # Find the last space in the string
-        split_at = text.rfind(b" ", 0, byte_length)
+        # Find the last newline in the string
+        split_at = text.rfind(b"\n", 0, byte_length)
+        if split_at < 0:
+            # Find the last space in the string
+            split_at = text.rfind(b" ", 0, byte_length)
 
-        # If no space found, split_at is byte_length
-        split_at = split_at if split_at != -1 else byte_length
+        if split_at < 0:
+            # If no space found, split_at is byte_length
+            # Verify that the text is valid UTF-8
+            split_at = byte_length
+            while split_at > 0:
+                try:
+                    text[:split_at].decode("utf-8")
+                    break
+                except UnicodeDecodeError:
+                    split_at -= 1
+            if split_at == 0:
+                raise ValueError("Byte length too small or text is invalid UTF-8.")
 
         # Verify all & are terminated with a ;
         while b"&" in text[:split_at]:


### PR DESCRIPTION
### Description
This PR improves the robustness of the `split_text_by_byte_length` function, which splits a UTF-8 string or bytes object into chunks with a specified maximum byte length.

### Problem
When no space (`b" "`) is found within the target byte range, the original code attempts to split directly at the byte limit. However, this can result in slicing through a multi-byte UTF-8 character, causing UnicodeDecodeError during decoding.

Additionally, the original logic didn't fully utilize newline characters (`\n`) as potential split points, for space is not mandated in some language such as Chinese.

### Fix
Added a UTF-8 boundary check: when splitting at an exact byte length, the code now walks backward to find a valid UTF-8 boundary if no safe space or newline is found.

Introduced support for splitting at the last newline (`b"\n"`) before falling back to spaces or raw byte length.